### PR TITLE
Fix #73 (liens des partis)

### DIFF
--- a/src/scripts/parti.js
+++ b/src/scripts/parti.js
@@ -107,7 +107,8 @@ function renderParti(parti) {
   }
 
   if (parti.siteWeb) {
-    Slots.setLink('site-web', parti.siteWeb, parti.siteWeb.replace(/^(https?:\/\/)?(www\.)?([^/]+).*$/, '$3'))
+    parti.siteWeb = coherentUrl(parti.siteWeb)
+    Slots.setLink('site-web', parti.siteWeb, parti.siteWeb.replace(/^(https?:\/\/)?(www\.)?(.*\.[^/]*).*$/, '$3'))
   } else {
     Slots.hide('site-web')
   }

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -84,6 +84,10 @@ function extractIdFromWikidataUrl(url) {
   return url?.match(/entity\/(Q\d+)$/)?.[1]
 }
 
+function coherentUrl(url) {
+    return url.match(/^https?:\/\//) ? url : `http://${url}`
+}
+
 function extractGenderFromWikidataUrl(url) {
   const genders = {
     Q6581097: 'M',


### PR DESCRIPTION
Ajout de la méthode coherentUrl qui ajoute http:// aux liens qui ne 
l'ont pas + fix de la regex qui affiche les liens dans parti.js.