### PR TITLE
issue72/Filtrage sur le hash complet

### DIFF
--- a/src/scripts/ideologie.js
+++ b/src/scripts/ideologie.js
@@ -1,17 +1,9 @@
-/* global Slots PolitifCache splitOnce requete_ideologie requete_ideologie_description requete_ideologies_parentes requete_ideologies_derivees wikidataUrl dbpediaUrl extractIdFromWikidataUrl ucfirst */
+/* global Slots PolitifCache splitOnce requete_ideologie requete_ideologie_description requete_ideologies_parentes requete_ideologies_derivees wikidataUrl dbpediaUrl extractIdFromWikidataUrl ucfirst checkHashOrRedirect */
 
 function update() {
+  checkHashOrRedirect()
+
   const hash = document.location.hash.slice(1)
-
-  const re = /^Q\d+-.+$/
-  if (!hash.match(re)) {
-    // redirection vers la page d'accueil (ou alors redir vers une 404.html ?)
-    document.location.replace("index.html")
-    // Utiliser .assign(…) pour ne pas retirer la page invalide de l'historique client,
-    // mais est-ce une propriété vraiment désirable ?
-    return // quitter la méthode update() sans rien faire
-  }
-
   const p = splitOnce(decodeURIComponent(hash), '-')
   const id = p.length > 0 ? p[0] : ''
   const nameWhileLoading = p.length > 1 ? p[1] : ''
@@ -41,7 +33,6 @@ function init() {
   update()
   window.addEventListener('hashchange', () => update())
 }
-
 init()
 
 function renderIdeologie(ideologie) {

--- a/src/scripts/profil.js
+++ b/src/scripts/profil.js
@@ -1,29 +1,9 @@
-/* global Slots PolitifCache wikidataUrl dbpediaUrl dateToHtml splitOnce ucfirst nullableDate requete_profil_biographie requete_profil_description requete_profil_mandats requete_profil_partiPolitique extractIdFromWikidataUrl requete_profil_enfants requete_profil_fratrie genrerFonction extractGenderFromWikidataUrl */
-
-function setLinkPoliticianOrHide(key, { id, nom, isPolitician = false }) {
-  if (nom) {
-    if (isPolitician) {
-      return Slots.setLink(key, `profil.html#${id}-${nom}`, nom)
-    } else {
-      return Slots.setText(key, nom)
-    }
-  } else {
-    return Slots.hide(key)
-  }
-}
+/* global Slots PolitifCache wikidataUrl dbpediaUrl dateToHtml splitOnce ucfirst nullableDate requete_profil_biographie requete_profil_description requete_profil_mandats requete_profil_partiPolitique extractIdFromWikidataUrl requete_profil_enfants requete_profil_fratrie genrerFonction extractGenderFromWikidataUrl checkHashOrRedirect setLinkPoliticianOrHide */
 
 function update() {
+  checkHashOrRedirect()
+
   const hash = document.location.hash.slice(1)
-
-  const re = /^Q\d+-.+$/
-  if (!hash.match(re)) {
-    // redirection vers la page d'accueil (ou alors redir vers une 404.html ?)
-    document.location.replace("index.html")
-    // Utiliser .assign(…) pour ne pas retirer la page invalide de l'historique client,
-    // mais est-ce une propriété vraiment désirable ?
-    return // quitter la méthode update() sans rien faire
-  }
-
   const p = splitOnce(decodeURIComponent(hash), '-')
   const id = p.length > 0 ? p[0] : ''
   const nameWhileLoading = p.length > 1 ? p[1] : ''

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -85,7 +85,7 @@ function extractIdFromWikidataUrl(url) {
 }
 
 function coherentUrl(url) {
-    return url.match(/^https?:\/\//) ? url : `http://${url}`
+  return url.match(/^https?:\/\//) ? url : `http://${url}`
 }
 
 function extractGenderFromWikidataUrl(url) {
@@ -177,4 +177,41 @@ function genrerFonction(genre, fonction) {
     }
     return fonction
   }
+}
+
+
+function adresseToText({ numero, rue, ville, codePostal }) {
+  if (numero && rue && ville && codePostal) {
+    return `${numero} ${rue}, ${ville} ${codePostal}`
+  } else if (numero && rue && ville) {
+    return `${numero} ${rue}, ${ville}`
+  } else if (rue && ville) {
+    return `${rue}, ${ville}`
+  } else if (ville) {
+    return ville
+  }
+}
+
+function setLinkPoliticianOrHide(key, { id, nom, isPolitician = false }) {
+  if (nom) {
+    if (isPolitician) {
+      return Slots.setLink(key, `profil.html#${id}-${encodeURIComponent(nom)}`, nom)
+    } else {
+      return Slots.setText(key, nom)
+    }
+  } else {
+    return Slots.hide(key)
+  }
+}
+
+function checkHashOrRedirect(pattern = /^Q\d+(-|$)/) {
+  const hash = document.location.hash.slice(1)
+  const valid = hash.match(pattern)
+  if (!valid) {
+    // redirection vers la page d'accueil (ou alors redir vers une 404.html ?)
+    document.location.replace('index.html')
+    // Utiliser .assign(…) pour ne pas retirer la page invalide de l'historique client,
+    // mais est-ce une propriété vraiment désirable ?
+  }
+  return valid
 }


### PR DESCRIPTION
J'ai pris la liberté de filtrer sur le hash complet, pour éviter qu'on n'ait pas de nom (peu importe ce qu'il contient).

Je suis pas contre de rediriger vers une page dédiée, mais plutôt autre chose que 404 Not Found, peut-être un 400 Bad Request ?
Quoiqu'il en soit c'est pas le plus urgent donc on pourra toujours voir ça à la fin.

Je peux éventuellement factoriser le code dans une fonction utilitaire, est-ce nécessaire ?
