### PR TITLE
Added some politicians for 2022 election

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
           'https://upload.wikimedia.org/wikipedia/commons/f/fb/Europe_Ecologie-Les_Verts_Logo.svg',
         ),
         featuredTopic(
-          'Q329', 'Valérie Pécresse', 'profil',
+          'Q455023', 'Valérie Pécresse', 'profil',
           'Q20012759', 'Les Républicains', 'parti',
           'https://upload.wikimedia.org/wikipedia/commons/a/a9/UMP_regional_elections_Paris_2010-01-21_n11.jpg',
         ),

--- a/index.html
+++ b/index.html
@@ -102,14 +102,64 @@
           'https://upload.wikimedia.org/wikipedia/commons/3/3a/Logo_France_Insoumise.svg',
         ),
         featuredTopic(
-          'Q157', 'François Hollande', 'profil',
+          'Q30388733', 'Fabien Roussel', 'profil',
+          'Q192821', 'Parti Communiste Français', 'parti',
+          'https://upload.wikimedia.org/wikipedia/commons/a/ae/Roussel_Fabien_1.jpg',
+        ),
+        featuredTopic(
+          'Q192821', 'Parti Communiste Français', 'parti',
+          'Q6186', 'Communisme', 'ideologie',
+          'https://upload.wikimedia.org/wikipedia/commons/a/a7/PCF_LOGO.svg',
+        ),
+        featuredTopic(
+          'Q439490', 'Nathalie Arthaud', 'profil',
+          'Q870667', 'Lutte Ouvrière', 'parti',
+          'https://upload.wikimedia.org/wikipedia/commons/b/b6/Nathalie_Arthaud.png',
+        ),
+        featuredTopic(
+          'Q870667', 'Lutte Ouvrière', 'parti',
+          'Q181133', 'Trotskisme', 'ideologie',
+          'https://upload.wikimedia.org/wikipedia/commons/5/5c/Logo_Lutte_Ouvri%C3%A8re.svg',
+        ),
+        featuredTopic(
+          'Q2631198', 'Philippe Poutou', 'profil',
+          'Q1045425', 'Nouveau Parti Anticapitaliste', 'parti',
+          'https://upload.wikimedia.org/wikipedia/commons/f/f2/Philippe_Poutou_-_Gilets_jaunes_%282019%29.jpg',
+        ),
+        featuredTopic(
+          'Q1045425', 'Nouveau Parti Anticapitaliste', 'parti',
+          'Q389647', 'Anti-capitalisme', 'ideologie',
+          'https://upload.wikimedia.org/wikipedia/fr/0/06/Logo_NPA.png',
+        ),
+        featuredTopic(
+          'Q106405647', 'Anasse Kazib', 'profil',
+          'Q22981822', 'Révolution Permanente', 'parti',
+          'https://upload.wikimedia.org/wikipedia/commons/e/ec/Anasse_Kazib_-_La_Voce_delle_Lotte_2020_%28cropped%29.png',
+        ),
+        featuredTopic(
+          'Q22981822', 'Révolution Permanente', 'parti',
+          'Q181133', 'Trotskisme', 'ideologie',
+          'https://upload.wikimedia.org/wikipedia/commons/b/b4/Leon_Trotsky%2C_1930s.jpg', // Do not have a better choice as there is no reference to the newly-created party in Wikipedia / WikiData.
+        ),
+        featuredTopic(
+          'Q2851133', 'Anne Hidalgo', 'profil',
           'Q170972', 'Parti Socialiste', 'parti',
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Francois_Hollande_2015.jpeg/160px-Francois_Hollande_2015.jpeg',
+          'https://upload.wikimedia.org/wikipedia/commons/4/4f/Anne_Hidalgo_2018_%28cropped%29.jpg',
         ),
         featuredTopic(
           'Q170972', 'Parti Socialiste', 'parti',
           'Q121254', 'Social-démocratie', 'ideologie',
           'https://upload.wikimedia.org/wikipedia/fr/f/fd/Ps-france-2016.svg',
+        ),
+        featuredTopic(
+          'Q268675', 'Christiane Taubira', 'profil',
+          'Q427965', 'Parti Radical de Gauche', 'parti',
+          'https://upload.wikimedia.org/wikipedia/commons/1/1e/Christiane_Taubira_par_Claude_Truong-Ngoc_juin_2013.jpg',
+        ),
+        featuredTopic(
+          'Q427965', 'Parti Radical de Gauche', 'parti',
+          'Q913401', 'Radicalisme', 'ideologie',
+          'https://upload.wikimedia.org/wikipedia/commons/7/71/Logo_-_PRG%2C_le_centre_gauche.svg',
         ),
         featuredTopic(
           'Q441791', 'Yannick Jadot', 'profil',
@@ -122,19 +172,9 @@
           'https://upload.wikimedia.org/wikipedia/commons/f/fb/Europe_Ecologie-Les_Verts_Logo.svg',
         ),
         featuredTopic(
-          'Q12963', 'François Bayrou', 'profil',
-          'Q587370', 'Mouvement Démocrate', 'parti',
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/BayrouEM.jpg/160px-BayrouEM.jpg',
-        ),
-        featuredTopic(
-          'Q587370', 'Mouvement Démocrate', 'parti',
-          'Q201712', 'Social-libéralisme', 'ideologie',
-          'https://upload.wikimedia.org/wikipedia/commons/9/94/MoDem_logo.svg',
-        ),
-        featuredTopic(
-          'Q329', 'Nicolas Sarkozy', 'profil',
+          'Q329', 'Valérie Pécresse', 'profil',
           'Q20012759', 'Les Républicains', 'parti',
-          'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c2/Nicolas_Sarkozy_%282015-10-29%29_03_%28cropped%29.jpg/160px-Nicolas_Sarkozy_%282015-10-29%29_03_%28cropped%29.jpg',
+          'https://upload.wikimedia.org/wikipedia/commons/a/a9/UMP_regional_elections_Paris_2010-01-21_n11.jpg',
         ),
         featuredTopic(
           'Q20012759', 'Les Républicains', 'parti',
@@ -150,6 +190,36 @@
           'Q205150', 'Rassemblement National', 'parti',
           'Q3874022', 'Nationalisme français', 'ideologie',
           'https://upload.wikimedia.org/wikipedia/commons/d/d5/Logo_Rassemblement_National.svg',
+        ),
+        featuredTopic(
+          'Q12961', 'Nicolas Dupoint-Aignan', 'profil',
+          'Q12962', 'Debout la France', 'parti',
+          'https://upload.wikimedia.org/wikipedia/commons/1/13/Nicolas_Dupont-Aignan%2C_homme_politique_fran%C3%A7ais.jpg',
+        ),
+        featuredTopic(
+          'Q12962', 'Debout la France', 'parti',
+          'Q852739', 'National-conservatisme', 'ideologie',
+          'https://upload.wikimedia.org/wikipedia/commons/9/9b/Logo-deboutlafrance-2017.png',
+        ),
+        featuredTopic(
+          'Q3074223', 'Florian Philippot', 'profil',
+          'Q41330182', 'Les Patriotes', 'parti',
+          'https://upload.wikimedia.org/wikipedia/commons/c/cb/Florian_Philippot_par_Claude_Truong-Ngoc_juillet_2014.jpg',
+        ),
+        featuredTopic(
+          'Q41330182', 'Les Patriotes', 'parti',
+          'Q6235', 'Nationalisme', 'ideologie',
+          'https://upload.wikimedia.org/wikipedia/fr/3/31/Les_Patriotes_2018.png',
+        ),
+        featuredTopic(
+          'Q288477', 'Éric Zemmour', 'profil',
+          'Q109932430', 'Reconquête!', 'parti',
+          'https://upload.wikimedia.org/wikipedia/commons/f/f0/%C3%89ric_Zemmour_10-2021.jpg',
+        ),
+        featuredTopic(
+          'Q109932430', 'Reconquête!', 'parti',
+          'Q852739', 'National-conservatisme', 'ideologie',
+          'https://upload.wikimedia.org/wikipedia/commons/5/5c/Logo_of_the_Reconquest_%28political_party%29.png',
         ),
       ])
     </script>


### PR DESCRIPTION
Added on home page : 
- Fabien Roussel / PCF
- Nathalie Arthaud / LO
- Philippe Poutou / NPA
- Anasse Kazib / RP
- Anne Hidalgo / PS
- Christiane Taubira / PRG
- Valérie Pécresse / LR
- Nicolas Dupont-Aignan / DLF
- Florian Philippot / LP
- Eric Zemmour / R!

Deleted on home page : 
- François Hollande / PS
- Nicolas Sarkozy / LR
- François Bayrou / MoDem

We need to check if we can add more candidates (Jean Lassalle, Georges Kuzmanovic, ...) but I think we can just wait for the definitive list and, in the meantime, have this list. If someone can review this code for any small mistakes (f.i. copy-paste errors on primary keys for each label in the hard-coded index.html fine)